### PR TITLE
close err channel on success

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kargakis/hystrix-go
+module github.com/afex/hystrix-go
 
 go 1.13
 

--- a/hystrix/eventstream.go
+++ b/hystrix/eventstream.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kargakis/hystrix-go/hystrix/rolling"
+	"github.com/afex/hystrix-go/hystrix/rolling"
 )
 
 const (

--- a/hystrix/hystrix.go
+++ b/hystrix/hystrix.go
@@ -176,6 +176,7 @@ func GoC(ctx context.Context, name string, run runFuncC, fallback fallbackFuncC)
 
 		select {
 		case <-cmd.finished:
+			close(cmd.errChan)
 			// returnOnce has been executed in another goroutine
 		case <-ctx.Done():
 			returnOnce.Do(func() {

--- a/hystrix/metric_collector/default_metric_collector.go
+++ b/hystrix/metric_collector/default_metric_collector.go
@@ -3,7 +3,7 @@ package metricCollector
 import (
 	"sync"
 
-	"github.com/kargakis/hystrix-go/hystrix/rolling"
+	"github.com/afex/hystrix-go/hystrix/rolling"
 )
 
 // DefaultMetricCollector holds information about the circuit state.

--- a/hystrix/metrics.go
+++ b/hystrix/metrics.go
@@ -5,8 +5,8 @@ import (
 	"sync"
 	"time"
 
-	metricCollector "github.com/kargakis/hystrix-go/hystrix/metric_collector"
-	"github.com/kargakis/hystrix-go/hystrix/rolling"
+	metricCollector "github.com/afex/hystrix-go/hystrix/metric_collector"
+	"github.com/afex/hystrix-go/hystrix/rolling"
 )
 
 type commandExecution struct {

--- a/hystrix/pool_metrics.go
+++ b/hystrix/pool_metrics.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/kargakis/hystrix-go/hystrix/rolling"
+	"github.com/afex/hystrix-go/hystrix/rolling"
 )
 
 type poolMetrics struct {

--- a/loadtest/service/main.go
+++ b/loadtest/service/main.go
@@ -11,9 +11,9 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/kargakis/hystrix-go/hystrix"
-	"github.com/kargakis/hystrix-go/hystrix/metric_collector"
-	"github.com/kargakis/hystrix-go/plugins"
+	"github.com/afex/hystrix-go/hystrix"
+	"github.com/afex/hystrix-go/hystrix/metric_collector"
+	"github.com/afex/hystrix-go/plugins"
 	"github.com/cactus/go-statsd-client/statsd"
 )
 

--- a/plugins/datadog_collector.go
+++ b/plugins/datadog_collector.go
@@ -5,7 +5,7 @@ import (
 	// Developed on https://github.com/DataDog/datadog-go/tree/a27810dd518c69be741a7fd5d0e39f674f615be8
 	"github.com/DataDog/datadog-go/statsd"
 
-	metricCollector "github.com/kargakis/hystrix-go/hystrix/metric_collector"
+	metricCollector "github.com/afex/hystrix-go/hystrix/metric_collector"
 )
 
 // These metrics are constants because we're leveraging the Datadog tagging
@@ -76,8 +76,8 @@ type (
 //  package main
 //
 //  import (
-//  	"github.com/kargakis/hystrix-go/plugins"
-//  	"github.com/kargakis/hystrix-go/hystrix/metric_collector"
+//  	"github.com/afex/hystrix-go/plugins"
+//  	"github.com/afex/hystrix-go/hystrix/metric_collector"
 //  )
 //
 //  func main() {

--- a/plugins/graphite_aggregator.go
+++ b/plugins/graphite_aggregator.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/rcrowley/go-metrics"
 
-	metricCollector "github.com/kargakis/hystrix-go/hystrix/metric_collector"
+	metricCollector "github.com/afex/hystrix-go/hystrix/metric_collector"
 )
 
 var makeTimerFunc = func() interface{} { return metrics.NewTimer() }

--- a/plugins/statsd_collector.go
+++ b/plugins/statsd_collector.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/cactus/go-statsd-client/statsd"
 
-	metricCollector "github.com/kargakis/hystrix-go/hystrix/metric_collector"
+	metricCollector "github.com/afex/hystrix-go/hystrix/metric_collector"
 )
 
 // StatsdCollector fulfills the metricCollector interface allowing users to ship circuit


### PR DESCRIPTION
Hi I'm using your fork and wanted to make a contribution.

Consider a function which simply returns an error.
```
err := foo()
```
Now to wrap this in hystrix I need to write code like this:
```
func safe_foo() error {

	output := make(chan bool, 1)
	errors := hystrix.Go("my_command", func() error {
		err := foo()
		if err == nil {
			output <- true
		}
		return err
	}, func(e error) error {
		err := bar()
		if err == nil {
			output <- true
		}
		return err
	})

	select {
	case out := <-output:
		return nil
	case err := <-errors:
		return err
	}
}
```

I find this approach very cumbersome, especially when I'm only interested in getting notified of when the hystrix command finishes, and error if any. If we close the error channel that's a good way of notifying the caller that the command has finished without error. Now this code looks a lot cleaner:
```
func safe_foo() error {

	err := <- hystrix.Go("my_command", func() error {
		return foo()
	}, func(e error) error {
		return bar()
	})

	return err
}
```

This works fine in my test program, but I would be glad to write a test case if you're interested in merging. And thanks for this fork!